### PR TITLE
Fixed Circle Bug

### DIFF
--- a/static/CardDrawing.js
+++ b/static/CardDrawing.js
@@ -176,8 +176,6 @@ function drawCircle(contextToAddTo, centerX, centerY, radius, color){
     contextToAddTo.strokeStyle = color;
     contextToAddTo.beginPath();
     contextToAddTo.arc(centerX, centerY, radius, 0, 2 * Math.PI);
-    contextToAddTo.stroke();
-    contextToAddTo.closePath();
     contextToAddTo.fill();
 }
 

--- a/static/kwunitGenerator.js
+++ b/static/kwunitGenerator.js
@@ -159,8 +159,8 @@
 		drawNameBar();
 
 		//size ball
-		drawCircle(contextToAddTo, 723, 118, 73, getFiligreeColor());
-		drawCircle(contextToAddTo, 723, 118, 64, getLightColor());
+		drawCircle(contextToAddTo, 724, 119, 73, getFiligreeColor());
+		drawCircle(contextToAddTo, 724, 118, 63, getLightColor());
 
 		//size label box
 		contextToAddTo.fillStyle = getLightColor();
@@ -171,7 +171,7 @@
 		contextToAddTo.fillRect(658, 383, 136, 157);
 
 		//tier ball
-		drawCircle(contextToAddTo, 725, 454, 51, getDarkColor());
+		drawCircle(contextToAddTo, 725, 453, 50, getDarkColor());
 
 		//tier label box
 		contextToAddTo.fillStyle = getLightColor();


### PR DESCRIPTION
Circles no longer get weirdly larger starting with the second draw per reload.
Stroke was doing a weird, but we don't need it anyway. Fill is sufficient.