### PR TITLE
Saved color schemes now immediately available, color schemes deletable

### DIFF
--- a/kw_units_app.py
+++ b/kw_units_app.py
@@ -95,10 +95,10 @@ def add_new_color_scheme(new_scheme_dict: dict, schemes_filepath: str, schemes_f
 
 
 def delete_color_scheme(form_dict: dict, schemes_filepath: str, schemes_filename: str):
-    name_of_scheme_to_delete = form_dict["to_delete"]
+    name_of_scheme_to_delete = form_dict["name"]
     with open(f"{schemes_filepath}/{schemes_filename}", "r+", encoding="utf-8") as schemes_file:
         schemes_json = loads(schemes_file.read())
-        schemes_json.pop(name_of_scheme_to_delete)
+        schemes_json["Color Schemes"] = [scheme for scheme in schemes_json["Color Schemes"] if scheme['name'] != name_of_scheme_to_delete]
         schemes_file.seek(0)
         schemes_file.truncate()
         schemes_file.write(dumps(schemes_json))

--- a/static/kwunitGenerator.js
+++ b/static/kwunitGenerator.js
@@ -402,6 +402,45 @@
 			console.warn("Did not save color scheme, blank name.");
 			return;
 		}
+
+		//dynamically create new option in dropdown
+		var option = document.createElement('option');
+		option.value = schemeName;
+		option.setAttribute("data-background-color", backgroundColor);
+		option.setAttribute("data-dark-color", darkColor);
+		option.setAttribute("data-light-color", lightColor);
+		option.setAttribute("data-filigree-color", filigreeColor);
+		option.innerHTML = schemeName;
+		document.getElementById("colorSelect").appendChild(option);
+
+		//dynamically create new entry in color scheme list
+		var entryName = document.createElement('dt');
+		entryName.class = "colorSchemeName";
+		entryName.innerHTML = schemeName;
+		var entryBg = document.createElement('dd');
+		entryBg.class = "colorSchemePreview";
+		entryBg.style.borderLeft = "18px solid " + backgroundColor;
+		entryBg.innerHTML = "Background Color: " + backgroundColor;
+		var entryDark = document.createElement('dd');
+		entryDark.class = "colorSchemePreview";
+		entryDark.style.borderLeft = "18px solid " + darkColor;
+		entryDark.innerHTML = "Dark Color: " + darkColor;
+		var entryLight = document.createElement('dd');
+		entryLight.class = "colorSchemePreview";
+		entryLight.style.borderLeft = "18px solid " + lightColor;
+		entryLight.innerHTML = "Light Color: " + lightColor;
+		var entryFiligree = document.createElement('dd');
+		entryFiligree.class = "colorSchemePreview";
+		entryFiligree.style.borderLeft = "18px solid " + filigreeColor;
+		entryFiligree.innerHTML = "Filigre Color: " + filigreeColor;
+		var table = document.getElementById("colorSchemesTable");
+		table.appendChild(entryName);
+		table.appendChild(entryBg);
+		table.appendChild(entryDark);
+		table.appendChild(entryLight);
+		table.appendChild(entryFiligree);
+
+		//Save to file by POST to API
 		var jsonData = {"name":schemeName,
 				"backgroundColor":backgroundColor,
 				"lightColor":lightColor,
@@ -413,7 +452,9 @@
 			contentType : "application/json",
 			type:"POST",
 			dataType:"json"
-		})
+		});
+		
+		alert(schemeName + " Color Scheme Saved.");
 	}
 
 	function LoadColor(){

--- a/static/kwunitGenerator.js
+++ b/static/kwunitGenerator.js
@@ -442,11 +442,11 @@
 
 		//Save to file by POST to API
 		var jsonData = {"name":schemeName,
-				"backgroundColor":backgroundColor,
-				"lightColor":lightColor,
-				"darkColor":darkColor,
-				"filigreeColor":filigreeColor
-			}
+			"backgroundColor":backgroundColor,
+			"lightColor":lightColor,
+			"darkColor":darkColor,
+			"filigreeColor":filigreeColor
+		}
 		$.ajax("/api/v1/colors",{
 			data : JSON.stringify(jsonData),
 			contentType : "application/json",
@@ -454,7 +454,7 @@
 			dataType:"json"
 		});
 		
-		alert(schemeName + " Color Scheme Saved.");
+		alert(schemeName + " color scheme saved.");
 	}
 
 	function LoadColor(){
@@ -472,19 +472,32 @@
 	}
 
 	function DeleteColor(){
-		var schemeName = $("#colorSchemeNameInput").val();
-		if (schemeName.trim() == ""){
-			console.warn("Did not delete color scheme, blank name.");
-			return;
+		var schemeName = $("#colorSelect").val();
+
+		//dynamically remove option from dropdown
+		document.getElementById("colorSelect").remove(document.getElementById("colorSelect").selectedIndex);
+
+		//dynamically remove entry from color scheme list
+		var rows = document.getElementsByClassName(schemeName + "Preview");
+		while (rows.length > 0) {
+			rows[0].remove();
 		}
-		var jsonData = {"name":schemeName
-			}
+
+		//Delete from file by DELETE to API
+		var jsonData = {"name":schemeName,
+			"backgroundColor":backgroundColor,
+			"lightColor":lightColor,
+			"darkColor":darkColor,
+			"filigreeColor":filigreeColor
+		}
 		$.ajax("/api/v1/colors",{
 			data : JSON.stringify(jsonData),
 			contentType : "application/json",
-			type:"POST",
+			type:"DELETE",
 			dataType:"json"
-		})
+		});
+		
+		alert(schemeName + " color scheme deleted.");
 	}
 
 	function componentToHex(c) {

--- a/static/kwunitGenerator.js
+++ b/static/kwunitGenerator.js
@@ -402,59 +402,9 @@
 			console.warn("Did not save color scheme, blank name.");
 			return;
 		}
-
-		//dynamically create new option in dropdown
-		var option = document.createElement('option');
-		option.value = schemeName;
-		option.setAttribute("data-background-color", backgroundColor);
-		option.setAttribute("data-dark-color", darkColor);
-		option.setAttribute("data-light-color", lightColor);
-		option.setAttribute("data-filigree-color", filigreeColor);
-		option.innerHTML = schemeName;
-		document.getElementById("colorSelect").appendChild(option);
-
-		//dynamically create new entry in color scheme list
-		var entryName = document.createElement('dt');
-		entryName.class = "colorSchemeName";
-		entryName.innerHTML = schemeName;
-		var entryBg = document.createElement('dd');
-		entryBg.class = "colorSchemePreview";
-		entryBg.style.borderLeft = "18px solid " + backgroundColor;
-		entryBg.innerHTML = "Background Color: " + backgroundColor;
-		var entryDark = document.createElement('dd');
-		entryDark.class = "colorSchemePreview";
-		entryDark.style.borderLeft = "18px solid " + darkColor;
-		entryDark.innerHTML = "Dark Color: " + darkColor;
-		var entryLight = document.createElement('dd');
-		entryLight.class = "colorSchemePreview";
-		entryLight.style.borderLeft = "18px solid " + lightColor;
-		entryLight.innerHTML = "Light Color: " + lightColor;
-		var entryFiligree = document.createElement('dd');
-		entryFiligree.class = "colorSchemePreview";
-		entryFiligree.style.borderLeft = "18px solid " + filigreeColor;
-		entryFiligree.innerHTML = "Filigre Color: " + filigreeColor;
-		var table = document.getElementById("colorSchemesTable");
-		table.appendChild(entryName);
-		table.appendChild(entryBg);
-		table.appendChild(entryDark);
-		table.appendChild(entryLight);
-		table.appendChild(entryFiligree);
-
-		//Save to file by POST to API
-		var jsonData = {"name":schemeName,
-			"backgroundColor":backgroundColor,
-			"lightColor":lightColor,
-			"darkColor":darkColor,
-			"filigreeColor":filigreeColor
-		}
-		$.ajax("/api/v1/colors",{
-			data : JSON.stringify(jsonData),
-			contentType : "application/json",
-			type:"POST",
-			dataType:"json"
-		});
-		
-		alert(schemeName + " color scheme saved.");
+		CreateColorSchemeDropdownOption(schemeName, backgroundColor, darkColor, lightColor, filigreeColor);
+		CreateColorSchemeTableEntry(schemeName, backgroundColor, darkColor, lightColor, filigreeColor);
+		SaveColorToFile(schemeName, backgroundColor, darkColor, lightColor, filigreeColor);
 	}
 
 	function LoadColor(){
@@ -473,17 +423,52 @@
 
 	function DeleteColor(){
 		var schemeName = $("#colorSelect").val();
+		DeleteSelectedColorSchemeDropdownOption()
+		DeleteColorSchemeTableEntry(schemeName);
+		DeleteColorSchemeFromFile(schemeName);
+	}
 
-		//dynamically remove option from dropdown
-		document.getElementById("colorSelect").remove(document.getElementById("colorSelect").selectedIndex);
+	function componentToHex(c) {
+		var hex = c.toString(16);
+		return hex.length == 1 ? "0" + hex : hex;
+	}
+	  
+	function rgbToHex(r, g, b) {
+		return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+	}
 
-		//dynamically remove entry from color scheme list
-		var rows = document.getElementsByClassName(schemeName + "Preview");
-		while (rows.length > 0) {
-			rows[0].remove();
-		}
+	function CreateColorSchemeDropdownOption(schemeName, backgroundColor, darkColor, lightColor, filigreeColor){
+		var option = document.createElement('option');
+		option.value = schemeName;
+		option.setAttribute("data-background-color", backgroundColor);
+		option.setAttribute("data-dark-color", darkColor);
+		option.setAttribute("data-light-color", lightColor);
+		option.setAttribute("data-filigree-color", filigreeColor);
+		option.innerHTML = schemeName;
+		document.getElementById("colorSelect").appendChild(option);
+	}
 
-		//Delete from file by DELETE to API
+	function CreateColorSchemeTableColorLine(name, color){
+		var entry = document.createElement('dd');
+		entry.class = "colorSchemePreview";
+		entry.style.borderLeft = "18px solid " + color;
+		entry.innerHTML = name + ": " + color;
+		return entry;
+	}
+
+	function CreateColorSchemeTableEntry(schemeName, backgroundColor, darkColor, lightColor, filigreeColor){
+		var entryName = document.createElement('dt');
+		entryName.class = "colorSchemeName";
+		entryName.innerHTML = schemeName;
+		var table = document.getElementById("colorSchemesTable");
+		table.appendChild(entryName);
+		table.appendChild(CreateColorSchemeTableColorLine("Backgound Color", backgroundColor));
+		table.appendChild(CreateColorSchemeTableColorLine("Dark Color", darkColor));
+		table.appendChild(CreateColorSchemeTableColorLine("Light Color", lightColor));
+		table.appendChild(CreateColorSchemeTableColorLine("Filigree Color", filigreeColor));
+	}
+
+	function SaveColorToFile(schemeName, backgroundColor, darkColor, lightColor, filigreeColor){
 		var jsonData = {"name":schemeName,
 			"backgroundColor":backgroundColor,
 			"lightColor":lightColor,
@@ -493,21 +478,31 @@
 		$.ajax("/api/v1/colors",{
 			data : JSON.stringify(jsonData),
 			contentType : "application/json",
+			type:"POST",
+			dataType:"json"
+		});
+	}
+
+	function DeleteSelectedColorSchemeDropdownOption(){
+		document.getElementById("colorSelect").remove(document.getElementById("colorSelect").selectedIndex);
+	}
+
+	function DeleteColorSchemeTableEntry(schemeName){
+		var rows = document.getElementsByClassName(schemeName + "Preview");
+		while (rows.length > 0) {
+			rows[0].remove();
+		}
+	}
+
+	function DeleteColorSchemeFromFile(schemeName){
+		var jsonData = {"name":schemeName}
+		$.ajax("/api/v1/colors",{
+			data : JSON.stringify(jsonData),
+			contentType : "application/json",
 			type:"DELETE",
 			dataType:"json"
 		});
-		
-		alert(schemeName + " color scheme deleted.");
 	}
-
-	function componentToHex(c) {
-		var hex = c.toString(16);
-		return hex.length == 1 ? "0" + hex : hex;
-	  }
-	  
-	  function rgbToHex(r, g, b) {
-		return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
-	  }
 	  
 
 })();

--- a/templates/index.html
+++ b/templates/index.html
@@ -242,11 +242,11 @@
 				<h2>Saved Color Schemes</h2>
 				<dl id="colorSchemesTable">
 					{% for colorScheme in colorSchemes %}
-					<dt class="colorSchemeName"> {{colorScheme["name"]}} </dt>
-					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Background Color"]}}">Background Color: {{colorScheme["Background Color"]}} </dd>
-					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Dark Color"]}}"> Dark Color: {{colorScheme["Dark Color"]}}</dd>
-					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Light Color"]}}"> Light Color: {{colorScheme["Light Color"]}} </dd>
-					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Filigree Color"]}}"> Filigree Color: {{colorScheme["Filigree Color"]}} </dd>
+					<dt class="colorSchemeName">{{colorScheme["name"]}}</dt>
+					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Background Color"]}}">Background Color: {{colorScheme["Background Color"]}}</dd>
+					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Dark Color"]}}">Dark Color: {{colorScheme["Dark Color"]}}</dd>
+					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Light Color"]}}">Light Color: {{colorScheme["Light Color"]}}</dd>
+					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Filigree Color"]}}">Filigree Color: {{colorScheme["Filigree Color"]}}</dd>
 					{% endfor %}
 				</dl>
 			</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -242,11 +242,11 @@
 				<h2>Saved Color Schemes</h2>
 				<dl id="colorSchemesTable">
 					{% for colorScheme in colorSchemes %}
-					<dt class="colorSchemeName">{{colorScheme["name"]}}</dt>
-					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Background Color"]}}">Background Color: {{colorScheme["Background Color"]}}</dd>
-					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Dark Color"]}}">Dark Color: {{colorScheme["Dark Color"]}}</dd>
-					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Light Color"]}}">Light Color: {{colorScheme["Light Color"]}}</dd>
-					<dd class="colorSchemePreview" style="border-left: 18px solid {{colorScheme["Filigree Color"]}}">Filigree Color: {{colorScheme["Filigree Color"]}}</dd>
+					<dt class="{{colorScheme["name"]}}Preview">{{colorScheme["name"]}}</dt>
+					<dd class="{{colorScheme["name"]}}Preview" style="border-left: 18px solid {{colorScheme["Background Color"]}}">Background Color: {{colorScheme["Background Color"]}}</dd>
+					<dd class="{{colorScheme["name"]}}Preview" style="border-left: 18px solid {{colorScheme["Dark Color"]}}">Dark Color: {{colorScheme["Dark Color"]}}</dd>
+					<dd class="{{colorScheme["name"]}}Preview" style="border-left: 18px solid {{colorScheme["Light Color"]}}">Light Color: {{colorScheme["Light Color"]}}</dd>
+					<dd class="{{colorScheme["name"]}}Preview" style="border-left: 18px solid {{colorScheme["Filigree Color"]}}">Filigree Color: {{colorScheme["Filigree Color"]}}</dd>
 					{% endfor %}
 				</dl>
 			</div>


### PR DESCRIPTION
Old behavior: saved color schemes didn't show up until reload. delete didn't work at all.

Added code to dynamically add an option to the dropdown and an entry to the schemes table on save. 

Deleting a color scheme now deletes the color scheme from file.
Added code to also dynamically delete the relevant dropdown option and preview table rows.

Also now alerts for successful save and delete.

(I would kinda like to know why it failed to run with jquery selectors on lines 414, 436, and 478 (`$("#colorSelect")`, `$("#colorSchemesTable")`, and `$("#colorSelect")` again, respectively)